### PR TITLE
Drop vestigial getDependencies() method.

### DIFF
--- a/NewsFlash/NewsFlash.php
+++ b/NewsFlash/NewsFlash.php
@@ -7,7 +7,7 @@ require_once 'Site/Site.php';
  * Container for package wide static methods
  *
  * @package   NewsFlash
- * @copyright 2012 silverorange
+ * @copyright 2012-2014 silverorange
  * @license   http://www.gnu.org/copyleft/lesser.html LGPL License 2.1
  */
 class NewsFlash
@@ -101,22 +101,6 @@ class NewsFlash
 
 		bindtextdomain(self::GETTEXT_DOMAIN, $path);
 		bind_textdomain_codeset(self::GETTEXT_DOMAIN, 'UTF-8');
-	}
-
-	// }}}
-	// {{{ public static function getDependencies()
-
-	/**
-	 * Gets the packages this package depends on
-	 *
-	 * @return array an array of package IDs that this package depends on.
-	 */
-	public static function getDependencies()
-	{
-		return array(
-			Swat::PACKAGE_ID,
-			Site::PACKAGE_ID
-		);
 	}
 
 	// }}}


### PR DESCRIPTION
That system is no longer used. Package-level dependencies for static files would be expressed in the dependencies/news-flash.yaml file.
